### PR TITLE
Automate build/release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: |
+          cmake -S . -B ./build -DCMAKE_BUILD_TYPE:STRING=Release
+          cmake --build ./build --config Release --target strip
+      - name: Release the new binary
+        if: github.ref == 'refs/heads/main'
+        uses: mini-bomba/create-github-release@v1.1.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: "latest"
+          prerelease: true
+          name: "Latest commit that compiles"
+          body: |
+            This automatic prerelease is built from commit ${{ github.sha }} and was triggered by @${{ github.actor }}
+            [Github Actions workflow run that built this prerelease](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+            Commit message:
+            ${{ github.event.head_commit.message }}
+          files: build/strip
+          clear_attachments: true


### PR DESCRIPTION
This will just make it easy to consume the binary from elsewhere without having to rebuild every time.
